### PR TITLE
Set up build with notebook content

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -3,5 +3,5 @@
 
 from documenteer.conf.technote import *  # noqa F401 F403
 
-nbsphinx_execute = 'never'
-exclude_patterns.append("notebooks")
+# Disable notebook execution with myst-nb
+nb_execution_mode = "off"

--- a/index.ipynb
+++ b/index.ipynb
@@ -7,9 +7,9 @@
    "source": [
     "# TMA Balancing Comparison\n",
     "\n",
-    "## Abstract\n",
-    "\n",
-    "We want to compare TMA Balancing data comparing different configurations. "
+    "```{abstract}\n",
+    "We want to compare TMA Balancing data comparing different configurations. \n",
+    "```"
    ]
   },
   {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-documenteer[technote]>=1.0.0a10
-nbsphinx
+documenteer[technote]>=1.0.0
 pandoc


### PR DESCRIPTION
- To avoid the lsst kernel issue, I found we have to explicitly prevent myst-nb from executing the notebook with the `nb_execution_mode = "off"` configuration.
- Marked up the abstract in markdown so it'll render consistently with other Sphinx technotes and also be scrape-able for www.lsst.io.